### PR TITLE
Change url_parser.cpp to use lambdas instead of ptr_fun

### DIFF
--- a/evpp/httpc/url_parser.cc
+++ b/evpp/httpc/url_parser.cc
@@ -29,7 +29,9 @@ int URLParser::parse(const string& url_s) {
     it = search(url_s.begin(), url_s.end(), prot_end.begin(), prot_end.end());
     if (it != url_s.end()) {
         schema.reserve(distance(url_s.begin(), it));
-        transform(url_s.begin(), it, back_inserter(schema), ptr_fun<int, int>(tolower)); // protocol is icase
+        transform(url_s.begin(), it, back_inserter(schema), [](int x) { // protocol is icase
+            return tolower(x);
+        });
         advance(it, prot_end.length());
         last_it = it;
     }
@@ -37,7 +39,9 @@ int URLParser::parse(const string& url_s) {
     it = find_if(last_it, url_s.end(), equal_key);
 
     host.reserve(distance(last_it, it));
-    transform(last_it, it, back_inserter(host), ptr_fun<int, int>(tolower)); // host is icase
+    transform(last_it, it, back_inserter(host), [](int x) { // host is icase
+        return tolower(x);
+    });
 
     if (it == url_s.end()) {
         return 0;


### PR DESCRIPTION
This enables evpp to be compiled and used with C++17.