### PR TITLE
Fix buffer overrun in udp_server_test.cc

### DIFF
--- a/test/udp_server_test.cc
+++ b/test/udp_server_test.cc
@@ -11,7 +11,7 @@ static void OnMessage(evpp::udp::Server* udpsrv, evpp::EventLoop* loop, const ev
     g_count++;
     evpp::udp::SendMessage(msg);
     usleep(100);
-    if (memcmp(msg->data(), "stop", msg->size()) == 0) {
+    if (msg->size() == 4 && memcmp(msg->data(), "stop", 4) == 0) {
         g_exit = true;
     }
 }


### PR DESCRIPTION
When `msg = "data xxx"` (for example from line 39), this does `memcmp(..., "stop", 8)`,
which reads past the end of the string literal.

Discovered via MSVC ASan 😸 